### PR TITLE
moved studies definition to common and include common.R 

### DIFF
--- a/common.R
+++ b/common.R
@@ -1,3 +1,11 @@
+
+# load specs
+library(tidyverse)
+studies <- data_frame(file = dir(path = "data_specifications")) %>%
+  mutate(file = str_replace(file, ".yaml", "")) %>%
+  separate(file, into = c("study","format"))
+
+
 # this code based on github.com/langcog/metalab2/scripts/cache_datsets.R
 # originally by Mika Braginksy (mikabr@mit.edu)
 

--- a/server.R
+++ b/server.R
@@ -5,10 +5,7 @@ library(tidyverse)
 
 source("common.R")
 
-studies <- data_frame(file = dir(path = "data_specifications")) %>%
-  mutate(file = str_replace(file, ".yaml", "")) %>%
-  separate(file, into = c("study","format"))
-  
+
 
 shinyServer(function(input, output, session) {
   output$study_format <- renderUI({

--- a/ui.R
+++ b/ui.R
@@ -1,5 +1,6 @@
 library(shiny)
 library(shinythemes)
+source("common.R")
 
 shinyUI(fluidPage(
   theme = shinytheme("spacelab"),


### PR DESCRIPTION
Fixed the bug. I moved the definition of variable 'studies' to common.R which is now sourced by both UI and server. It makes sense to define a single, common place for the definition of that variable (alternatively, create something like an init.R file).
