### PR TITLE
Adding fail message for uppercase letters

### DIFF
--- a/common.R
+++ b/common.R
@@ -74,6 +74,8 @@ validate_dataset_field <- function(dataset_contents, field) {
         if (field$format == "uncapitalized"){
           isCap = str_detect(field_contents, "[:upper:]")
           if (TRUE %in% isCap){
+            cat(sprintf("Dataset has a uppercase letter in lowercase-only field '%s'.\n",
+                        field$field))
             return(FALSE)
           }
         } 


### PR DESCRIPTION
Forgot to include a message explaining why the validation fails when there is an uppercase letter in a lowercase-only field.