### PR TITLE
print "Specifications" as a reactive table.

### DIFF
--- a/common.R
+++ b/common.R
@@ -103,6 +103,27 @@ validate_dataset <- function(fields, dataset_contents) {
 }
 
 
+# Convert yaml to tibble
+yaml2tib <- function(input){
+  
+  yaml_tib <- 
+    tibble(
+      Variable = map(input, "field"),
+      Description = map(input, "description"),
+      Type = map(input, "type"),
+      Format = map(input, "format"),
+      Example = map(input, "example"),
+      Required = map(input, "required"),
+      NA_allowed = map(input, "NA_allowed")
+      ) %>% 
+    mutate(
+      Required = if_else(Required == TRUE, "Yes", "No"),
+      NA_allowed = if_else(NA_allowed == TRUE, "Yes", "No")
+      )
+  
+  return(yaml_tib)
+}
+
 # # Manipulate a dataset's contents to prepare it for saving
 # tidy_dataset <- function(fields, dataset_contents) {
 #   

--- a/server.R
+++ b/server.R
@@ -1,23 +1,30 @@
 library(shiny)
 library(tidyverse)
 library(yaml)
+library(reactable)
 
 source("common.R")
 
 
-
 shinyServer(function(input, output, session) {
+  
   output$study_format <- renderUI({
     selectInput("format", label = h4("Study Format"),
                 choices = filter(studies, study == input$study)$format)
   })
   
-  output$specification <- renderPrint({
-    yaml::yaml.load_file(paste0("data_specifications/",
-                                input$study, "_", input$format, 
-                                ".yaml"))
-  })
-    
+  output$specification <- renderReactable({
+    reactable(
+        yaml2tib(yaml::read_yaml(paste0("data_specifications/",
+                                        input$study, "_", input$format, 
+                                        ".yaml"))), 
+        highlight = TRUE,
+        defaultPageSize = 5, 
+        showPageSizeOptions = TRUE,
+        searchable = TRUE
+        )
+      })
+
   output$validator_output <- renderPrint({
     req(input$file) 
     

--- a/ui.R
+++ b/ui.R
@@ -1,5 +1,6 @@
 library(shiny)
 library(shinythemes)
+library(reactable)
 source("common.R")
 
 shinyUI(fluidPage(
@@ -26,7 +27,7 @@ shinyUI(fluidPage(
                  verbatimTextOutput("validator_output")),
         tabPanel("Specification", 
                  p('This is the full text of the specification you have chosen'),
-                 verbatimTextOutput("specification"))
+                 reactableOutput("specification"))
       )
     )
   )


### PR DESCRIPTION
A small cosmetic change. Now the Specifications are printed as reactives tables instead of raw yaml. 